### PR TITLE
Incorporate Camera View Shake Reduction Into Recoil Reduction

### DIFF
--- a/ServerExt/Classes/ExtPerkManager.uc
+++ b/ServerExt/Classes/ExtPerkManager.uc
@@ -516,6 +516,11 @@ simulated function ModifyRecoil(out float CurrentRecoilModifier, KFWeapon KFW)
 		CurrentPerk.ModifyRecoil(CurrentRecoilModifier,KFW);
 }
 
+simulated function float GetCameraViewShakeModifier(KFWeapon KFW)
+{ 
+    return (CurrentPerk!=None ? CurrentPerk.GetCameraViewShakeModifier( KFW) : 1.f);
+}
+
 simulated function ModifySpread(out float InSpread)
 {
 	if (CurrentPerk!=None)

--- a/ServerExt/Classes/ExtPerkManager.uc
+++ b/ServerExt/Classes/ExtPerkManager.uc
@@ -518,7 +518,7 @@ simulated function ModifyRecoil(out float CurrentRecoilModifier, KFWeapon KFW)
 
 simulated function float GetCameraViewShakeModifier(KFWeapon KFW)
 { 
-    return (CurrentPerk!=None ? CurrentPerk.GetCameraViewShakeModifier( KFW) : 1.f);
+	return (CurrentPerk!=None ? CurrentPerk.GetCameraViewShakeModifier(KFW) : 1.f);
 }
 
 simulated function ModifySpread(out float InSpread)

--- a/ServerExt/Classes/Ext_PerkBase.uc
+++ b/ServerExt/Classes/Ext_PerkBase.uc
@@ -1295,7 +1295,7 @@ simulated function float GetReloadRateScale(KFWeapon KFW)
 
 simulated function float GetCameraViewShakeModifier(KFWeapon KFW)
 { 
-return Modifiers[2];
+	return Modifiers[2];
 }
 
 function ModifyHealth(out int InHealth)

--- a/ServerExt/Classes/Ext_PerkBase.uc
+++ b/ServerExt/Classes/Ext_PerkBase.uc
@@ -1293,6 +1293,11 @@ simulated function float GetReloadRateScale(KFWeapon KFW)
 	return (IsWeaponOnPerk(KFW) ? Modifiers[5] : 1.f);
 }
 
+simulated function float GetCameraViewShakeModifier(KFWeapon KFW)
+{ 
+return Modifiers[2];
+}
+
 function ModifyHealth(out int InHealth)
 {
 	InHealth *= Modifiers[6];


### PR DESCRIPTION
Makes the camera shake when using weapons like gunslinger's s & w 500 magnums be less annoying as you put points into the recoil stat. 