### PR TITLE
make knockdown stat push enemies back similar to heat wave or berserker weapons

### DIFF
--- a/ServerExt/Classes/ExtPerkManager.uc
+++ b/ServerExt/Classes/ExtPerkManager.uc
@@ -557,7 +557,7 @@ function float GetKnockdownPowerModifier(optional class<DamageType> DamageType, 
 
 function float GetStumblePowerModifier(optional KFPawn KFP, optional class<KFDamageType> DamageType, optional out float CooldownModifier, optional byte BodyPart)
 {
-	return (CurrentPerk!=None ? CurrentPerk.GetKnockdownPowerModifier() : 1.f);
+	return (CurrentPerk!=None ? CurrentPerk.GetStumblePowerModifier() : 1.f);
 }
 
 function float GetStunPowerModifier(optional class<DamageType> DamageType, optional byte HitZoneIdx)

--- a/ServerExt/Classes/Ext_PerkBase.uc
+++ b/ServerExt/Classes/Ext_PerkBase.uc
@@ -1313,6 +1313,11 @@ function float GetStunPowerModifier(optional class<DamageType> DamageType, optio
 	return Modifiers[7];
 }
 
+function float GetStumblePowerModifier( optional KFPawn KFP, optional class<KFDamageType> DamageType, optional out float CooldownModifier, optional byte BodyPart )
+{
+    return Modifiers[7];
+}
+
 simulated function ModifyMeleeAttackSpeed(out float InDuration);
 
 function AddDefaultInventory(KFPawn P)

--- a/ServerExt/Classes/Ext_PerkBase.uc
+++ b/ServerExt/Classes/Ext_PerkBase.uc
@@ -1315,7 +1315,7 @@ function float GetStunPowerModifier(optional class<DamageType> DamageType, optio
 
 function float GetStumblePowerModifier( optional KFPawn KFP, optional class<KFDamageType> DamageType, optional out float CooldownModifier, optional byte BodyPart )
 {
-    return Modifiers[7];
+	return Modifiers[7];
 }
 
 simulated function ModifyMeleeAttackSpeed(out float InDuration);

--- a/ServerExt/Classes/Ext_PerkSWAT.uc
+++ b/ServerExt/Classes/Ext_PerkSWAT.uc
@@ -28,6 +28,16 @@ simulated function float GetZedTimeModifier(KFWeapon W)
 	return 0.f;
 }
 
+function float GetStumblePowerModifier( optional KFPawn KFP, optional class<KFDamageType> DamageType, optional out float CooldownModifier, optional byte BodyPart )
+{
+    if( bRapidAssault)
+    {
+        return 2.f*Modifiers[7];
+    }
+
+    return Modifiers[7];
+}
+
 defaultproperties
 {
 	PerkIcon=Texture2D'UI_PerkIcons_TEX.UI_PerkIcon_SWAT'

--- a/ServerExt/Classes/Ext_PerkSWAT.uc
+++ b/ServerExt/Classes/Ext_PerkSWAT.uc
@@ -30,12 +30,12 @@ simulated function float GetZedTimeModifier(KFWeapon W)
 
 function float GetStumblePowerModifier( optional KFPawn KFP, optional class<KFDamageType> DamageType, optional out float CooldownModifier, optional byte BodyPart )
 {
-    if( bRapidAssault)
-    {
-        return 2.f*Modifiers[7];
-    }
+	if (bRapidAssault)
+	{
+		return 2.f * Modifiers[7];
+	}
 
-    return Modifiers[7];
+	return Modifiers[7];
 }
 
 defaultproperties


### PR DESCRIPTION
Currently, Knockdown/knockback only really stuns if it does anything. Adding stumblepower to the variable makes stuff actually get pushed back, instead of being stunned or nothing.